### PR TITLE
Disable March Madness cron

### DIFF
--- a/.github/workflows/march-madness.yml
+++ b/.github/workflows/march-madness.yml
@@ -1,8 +1,6 @@
 name: March Madness
 
 on:
-  schedule:
-    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This removes the scheduled trigger from the March Madness workflow. Manual runs via workflow_dispatch remain available.\n\nTested with CI=true npm test -- --watchAll=false.